### PR TITLE
remove "Arduino" word in name field in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,4 +1,4 @@
-name=Arduino ILI9163C STM32
+name=ILI9163C STM32
 version=1.0.2
 author=Pawel A. Hernik
 maintainer=Pawel A. Hernik <pawelhernik123@gmail.com>


### PR DESCRIPTION
To be compliant with Library Manager FAQ

>    A library is not valid when:
>
>      - it's not in 1.5 format and in particular it misses a library.properties file (1.5 format folder layout is not required)
>       - **its name field in library.properties starts with Arduino**